### PR TITLE
Added close stream by keeper

### DIFF
--- a/01-Contracts/contracts/StreamExchange.sol
+++ b/01-Contracts/contracts/StreamExchange.sol
@@ -111,7 +111,7 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
      *************************************************************************/
 
     /// @dev If a new stream is opened, or an existing one is opened
-  function _updateOutflow(bytes calldata ctx, bytes calldata agreementData, bool dobuteFirst)
+  function _updateOutflow(bytes calldata ctx, bytes calldata agreementData, bool doDistributeFirst)
       private
       returns (bytes memory newCtx)
   {
@@ -123,7 +123,7 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
                                                                          address(this),
                                                                          _exchange.outputIndexId);
 
-    if (dobuteFirst && totalUnitsApproved + totalUnitsPending > 0 && ISuperToken(_exchange.inputToken).balanceOf(address(this)) > 0) {
+    if (doDistributeFirst && totalUnitsApproved + totalUnitsPending > 0 && ISuperToken(_exchange.inputToken).balanceOf(address(this)) > 0) {
       newCtx = _exchange._distribute(newCtx);
     }
 


### PR DESCRIPTION
There needs to be a way for Ricochet keepers to help prevent streamers from getting slashed when their balance runs out. 

This enhancement adds a way for keepers to close streams once the streamer has less than enough balance to stream for 8 hours. Superfluids penalty kicks in at the 4 hour marker, the cost to not close a stream is the amount that'd stream over 4 hours, this is a deposit you put down to guarantee you will close your stream.