### PR TITLE
V1.3: Added unlimited approvals for input and output tokens

### DIFF
--- a/01-Contracts/contracts/StreamExchange.sol
+++ b/01-Contracts/contracts/StreamExchange.sol
@@ -1,33 +1,21 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 // import "hardhat/console.sol";
 
-import {
-    ISuperfluid,
-    ISuperToken,
-    ISuperApp,
-    ISuperAgreement,
-    SuperAppDefinitions
-} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";//"@superfluid-finance/ethereum-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
+import {ISuperfluid, ISuperToken, ISuperApp, ISuperAgreement, SuperAppDefinitions} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol"; //"@superfluid-finance/ethereum-monorepo/packages/ethereum-contracts/contracts/interfaces/superfluid/ISuperfluid.sol";
 
-import {
-    IConstantFlowAgreementV1
-} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/agreements/IConstantFlowAgreementV1.sol";
+import {IConstantFlowAgreementV1} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/agreements/IConstantFlowAgreementV1.sol";
 
-import {
-    IInstantDistributionAgreementV1
-} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/agreements/IInstantDistributionAgreementV1.sol";
+import {IInstantDistributionAgreementV1} from "@superfluid-finance/ethereum-contracts/contracts/interfaces/agreements/IInstantDistributionAgreementV1.sol";
 
-import {
-    SuperAppBase
-} from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperAppBase.sol";
+import {SuperAppBase} from "@superfluid-finance/ethereum-contracts/contracts/apps/SuperAppBase.sol";
 
-import '@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol';
-import '@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol';
+import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
+import "@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol";
 
-import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -37,9 +25,7 @@ import "./StreamExchangeStorage.sol";
 import "./StreamExchangeHelper.sol";
 import "./tellor/ITellor.sol";
 
-
 contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
-
     // TODO: uint256 public constant RATE_PERCISION = 1000000;
     using SafeERC20 for ERC20;
     using StreamExchangeHelper for StreamExchangeStorage.StreamExchange;
@@ -51,15 +37,15 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
     constructor(
         ISuperfluid host,
         IConstantFlowAgreementV1 cfa,
-        IInstantDistributionAgreementV1  ida,
+        IInstantDistributionAgreementV1 ida,
         ISuperToken inputToken,
         ISuperToken outputToken,
         ISuperToken subsidyToken,
         IUniswapV2Router02 sushiRouter,
         address payable oracle,
         uint256 requestId,
-        string memory registrationKey)
-        UsingTellor(oracle) {
+        string memory registrationKey
+    ) UsingTellor(oracle) {
         require(address(host) != address(0), "host");
         require(address(cfa) != address(0), "cfa");
         require(address(ida) != address(0), "ida");
@@ -82,13 +68,19 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
         _exchange.subsidyRate = 4e17; // 0.4 tokens/second ~ 1,000,000 tokens in a month
         _exchange.owner = msg.sender;
 
-        uint256 configWord =
-            SuperAppDefinitions.APP_LEVEL_FINAL |
+        // Unlimited approve for sushiswap
+        ERC20(_exchange.inputToken.getUnderlyingToken()).safeIncreaseAllowance(address(_exchange.sushiRouter), 2**256 - 1);
+        ERC20(_exchange.outputToken.getUnderlyingToken()).safeIncreaseAllowance(address(_exchange.sushiRouter), 2**256 - 1);
+        // and Supertoken upgrades
+        ERC20(_exchange.inputToken.getUnderlyingToken()).safeIncreaseAllowance(address(_exchange.inputToken), 2**256 - 1);
+        ERC20(_exchange.outputToken.getUnderlyingToken()).safeIncreaseAllowance(address(_exchange.outputToken), 2**256 - 1);
+
+        uint256 configWord = SuperAppDefinitions.APP_LEVEL_FINAL |
             SuperAppDefinitions.BEFORE_AGREEMENT_CREATED_NOOP |
             SuperAppDefinitions.BEFORE_AGREEMENT_UPDATED_NOOP |
             SuperAppDefinitions.BEFORE_AGREEMENT_TERMINATED_NOOP;
 
-        if(bytes(registrationKey).length > 0) {
+        if (bytes(registrationKey).length > 0) {
             _exchange.host.registerAppWithKey(configWord, registrationKey);
         } else {
             _exchange.host.registerApp(configWord);
@@ -98,7 +90,12 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
         _exchange._createIndex(_exchange.outputIndexId, _exchange.outputToken);
 
         // Give the owner 1 share just to start up the contract
-        _exchange._updateSubscription(_exchange.outputIndexId, msg.sender, 1, _exchange.outputToken);
+        _exchange._updateSubscription(
+            _exchange.outputIndexId,
+            msg.sender,
+            1,
+            _exchange.outputToken
+        );
 
         // Setup Liquidity Mining
         _exchange._initalizeLiquidityMining();
@@ -111,244 +108,286 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
      *************************************************************************/
 
     /// @dev If a new stream is opened, or an existing one is opened
-  function _updateOutflow(bytes calldata ctx, bytes calldata agreementData, bool doDistributeFirst)
-      private
-      returns (bytes memory newCtx)
-  {
+    function _updateOutflow(
+        bytes calldata ctx,
+        bytes calldata agreementData,
+        bool doDistributeFirst
+    ) private returns (bytes memory newCtx) {
+        newCtx = ctx;
 
-    newCtx = ctx;
+        (, , uint128 totalUnitsApproved, uint128 totalUnitsPending) = _exchange
+            .ida
+            .getIndex(
+                _exchange.outputToken,
+                address(this),
+                _exchange.outputIndexId
+            );
 
-    (, , uint128 totalUnitsApproved, uint128 totalUnitsPending) = _exchange.ida.getIndex(
-                                                                         _exchange.outputToken,
-                                                                         address(this),
-                                                                         _exchange.outputIndexId);
+        if (
+            doDistributeFirst &&
+            totalUnitsApproved + totalUnitsPending > 0 &&
+            ISuperToken(_exchange.inputToken).balanceOf(address(this)) > 0
+        ) {
+            newCtx = _exchange._distribute(newCtx);
+        }
 
-    if (doDistributeFirst && totalUnitsApproved + totalUnitsPending > 0 && ISuperToken(_exchange.inputToken).balanceOf(address(this)) > 0) {
-      newCtx = _exchange._distribute(newCtx);
+        (address requester, address flowReceiver) = abi.decode(
+            agreementData,
+            (address, address)
+        );
+        int96 changeInFlowRate = _exchange.cfa.getNetFlow(
+            _exchange.inputToken,
+            address(this)
+        ) - _exchange.totalInflow;
+
+        _exchange.streams[requester].rate =
+            _exchange.streams[requester].rate +
+            changeInFlowRate;
+
+        // Make sure the requester has at least 8 hours of balance to stream
+        require(
+            int256(_exchange.inputToken.balanceOf(requester)) >=
+                _exchange.streams[requester].rate * 8 hours,
+            "!enoughTokens"
+        );
+
+        newCtx = _exchange._updateSubscriptionWithContext(
+            newCtx,
+            _exchange.outputIndexId,
+            requester,
+            uint128(uint256(int256(_exchange.streams[requester].rate))),
+            _exchange.outputToken
+        );
+        newCtx = _exchange._updateSubscriptionWithContext(
+            newCtx,
+            _exchange.subsidyIndexId,
+            requester,
+            uint128(uint256(int256(_exchange.streams[requester].rate))),
+            _exchange.subsidyToken
+        );
+
+        _exchange.totalInflow = _exchange.totalInflow + changeInFlowRate;
+
+        emit UpdatedStream(
+            requester,
+            _exchange.streams[requester].rate,
+            _exchange.totalInflow
+        );
     }
 
-    (address requester, address flowReceiver) = abi.decode(agreementData, (address, address));
-    int96 changeInFlowRate = _exchange.cfa.getNetFlow(_exchange.inputToken, address(this)) - _exchange.totalInflow;
-
-    _exchange.streams[requester].rate = _exchange.streams[requester].rate + changeInFlowRate;
-
-    // Make sure the requester has at least 8 hours of balance to stream
-    require(int(_exchange.inputToken.balanceOf(requester)) >= _exchange.streams[requester].rate * 8 hours, "!enoughTokens");
-
-    newCtx = _exchange._updateSubscriptionWithContext(newCtx, _exchange.outputIndexId, requester, uint128(uint(int(_exchange.streams[requester].rate))), _exchange.outputToken);
-    newCtx = _exchange._updateSubscriptionWithContext(newCtx, _exchange.subsidyIndexId, requester, uint128(uint(int(_exchange.streams[requester].rate))), _exchange.subsidyToken);
-
-    _exchange.totalInflow = _exchange.totalInflow + changeInFlowRate;
-
-    emit UpdatedStream(requester, _exchange.streams[requester].rate, _exchange.totalInflow);
-
-  }
-
-
-  function distribute() external {
-   _exchange._distribute(new bytes(0));
-  }
-
-  function closeStream(address streamer) public {
-    _exchange._closeStream(streamer);
-  }
-
-  function emergencyCloseStream(address streamer) public {
-    _exchange._emergencyCloseStream(streamer);
-  }
-
-  function setSubsidyRate(uint128 subsidyRate) external onlyOwner {
-    _exchange.subsidyRate = subsidyRate;
-  }
-
-  function setFeeRate(uint128 feeRate) external onlyOwner {
-    _exchange.feeRate = feeRate;
-  }
-
-  function setRateTolerance(uint128 rateTolerance) external onlyOwner {
-    _exchange.rateTolerance = rateTolerance;
-  }
-
-  function setOracle(address oracle) external onlyOwner {
-    _exchange.oracle = ITellor(oracle);
-  }
-
-  function setRequestId(uint256 requestId) external onlyOwner {
-    _exchange.requestId = requestId;
-  }
-
-  function isAppJailed() external view returns (bool) {
-   return _exchange.host.isAppJailed(this);
-  }
-
-  function getIDAShares(uint32 index, address streamer) external view returns (bool exist,
-                bool approved,
-                uint128 units,
-                uint256 pendingDistribution) {
-
-    ISuperToken idaToken;
-    if(index == _exchange.outputIndexId) {
-
-      idaToken = _exchange.outputToken;
-
-    } else if (index == _exchange.subsidyIndexId) {
-
-      idaToken = _exchange.subsidyToken;
-
-    } else {
-      return (exist, approved, units, pendingDistribution);
+    function distribute() external {
+        _exchange._distribute(new bytes(0));
     }
 
-    (exist, approved, units, pendingDistribution) = _exchange.ida.getSubscription(
-                                                                  idaToken,
-                                                                  address(this),
-                                                                  index,
-                                                                  streamer);
-  }
+    function closeStream(address streamer) public {
+        _exchange._closeStream(streamer);
+    }
 
-  function getInputToken() external view returns (ISuperToken) {
-   return _exchange.inputToken;
-  }
+    function emergencyCloseStream(address streamer) public {
+        _exchange._emergencyCloseStream(streamer);
+    }
 
-  function getOuputToken() external view returns (ISuperToken) {
-   return _exchange.outputToken;
-  }
+    function setSubsidyRate(uint128 subsidyRate) external onlyOwner {
+        _exchange.subsidyRate = subsidyRate;
+    }
 
-  function getOuputIndexId() external view returns (uint32) {
-   return _exchange.outputIndexId;
-  }
+    function setFeeRate(uint128 feeRate) external onlyOwner {
+        _exchange.feeRate = feeRate;
+    }
 
-  function getSubsidyToken() external view returns (ISuperToken) {
-   return _exchange.subsidyToken;
-  }
+    function setRateTolerance(uint128 rateTolerance) external onlyOwner {
+        _exchange.rateTolerance = rateTolerance;
+    }
 
-  function getSubsidyIndexId() external view returns (uint32) {
-   return _exchange.subsidyIndexId;
-  }
+    function setOracle(address oracle) external onlyOwner {
+        _exchange.oracle = ITellor(oracle);
+    }
 
-  function getSubsidyRate() external view returns (uint256) {
-    return _exchange.subsidyRate;
-  }
+    function setRequestId(uint256 requestId) external onlyOwner {
+        _exchange.requestId = requestId;
+    }
 
-  function getTotalInflow() external view returns (int96) {
-    return _exchange.totalInflow;
-  }
+    function isAppJailed() external view returns (bool) {
+        return _exchange.host.isAppJailed(this);
+    }
 
-  function getLastDistributionAt() external view returns (uint256) {
-    return _exchange.lastDistributionAt;
-  }
+    function getIDAShares(uint32 index, address streamer)
+        external
+        view
+        returns (
+            bool exist,
+            bool approved,
+            uint128 units,
+            uint256 pendingDistribution
+        )
+    {
+        ISuperToken idaToken;
+        if (index == _exchange.outputIndexId) {
+            idaToken = _exchange.outputToken;
+        } else if (index == _exchange.subsidyIndexId) {
+            idaToken = _exchange.subsidyToken;
+        } else {
+            return (exist, approved, units, pendingDistribution);
+        }
 
-  function getSushiRouter() external view returns (address) {
-    return address(_exchange.sushiRouter);
-  }
+        (exist, approved, units, pendingDistribution) = _exchange
+            .ida
+            .getSubscription(idaToken, address(this), index, streamer);
+    }
 
-  function getTellorOracle() external view returns (address) {
-    return address(_exchange.oracle);
-  }
+    function getInputToken() external view returns (ISuperToken) {
+        return _exchange.inputToken;
+    }
 
-  function getRequestId() external view returns (uint256) {
-    return _exchange.requestId;
-  }
+    function getOuputToken() external view returns (ISuperToken) {
+        return _exchange.outputToken;
+    }
 
-  function getOwner() external view returns (address) {
-    return _exchange.owner;
-  }
+    function getOuputIndexId() external view returns (uint32) {
+        return _exchange.outputIndexId;
+    }
 
-  function getFeeRate() external view returns (uint128) {
-    return _exchange.feeRate;
-  }
+    function getSubsidyToken() external view returns (ISuperToken) {
+        return _exchange.subsidyToken;
+    }
 
-  function getRateTolerance() external view returns (uint256) {
-    return _exchange.rateTolerance;
-  }
+    function getSubsidyIndexId() external view returns (uint32) {
+        return _exchange.subsidyIndexId;
+    }
 
-  function getStreamRate(address streamer) external view returns (int96) {
-    return _exchange.streams[streamer].rate;
-  }
+    function getSubsidyRate() external view returns (uint256) {
+        return _exchange.subsidyRate;
+    }
 
+    function getTotalInflow() external view returns (int96) {
+        return _exchange.totalInflow;
+    }
 
+    function getLastDistributionAt() external view returns (uint256) {
+        return _exchange.lastDistributionAt;
+    }
 
-  /**
+    function getSushiRouter() external view returns (address) {
+        return address(_exchange.sushiRouter);
+    }
+
+    function getTellorOracle() external view returns (address) {
+        return address(_exchange.oracle);
+    }
+
+    function getRequestId() external view returns (uint256) {
+        return _exchange.requestId;
+    }
+
+    function getOwner() external view returns (address) {
+        return _exchange.owner;
+    }
+
+    function getFeeRate() external view returns (uint128) {
+        return _exchange.feeRate;
+    }
+
+    function getRateTolerance() external view returns (uint256) {
+        return _exchange.rateTolerance;
+    }
+
+    function getStreamRate(address streamer) external view returns (int96) {
+        return _exchange.streams[streamer].rate;
+    }
+
+    /**
      * @dev Transfers ownership of the contract to a new account (`newOwner`).
      * Can only be called by the current owner.
      * NOTE: Override this to add changing the
      */
-    function transferOwnership(address newOwner) public virtual override onlyOwner {
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override
+        onlyOwner
+    {
         super.transferOwnership(newOwner);
         _exchange.owner = newOwner;
     }
 
-  /**************************************************************************
-   * SuperApp callbacks
-   *************************************************************************/
+    /**************************************************************************
+     * SuperApp callbacks
+     *************************************************************************/
 
-  function afterAgreementCreated(
-      ISuperToken _superToken,
-      address _agreementClass,
-      bytes32, // _agreementId,
-      bytes calldata _agreementData,
-      bytes calldata ,// _cbdata,
-      bytes calldata _ctx
-  )
-      external override
-      onlyExpected(_superToken, _agreementClass)
-      onlyHost
-      returns (bytes memory newCtx)
-  {
-      if (!_exchange._isInputToken(_superToken) || !_exchange._isCFAv1(_agreementClass)) return _ctx;
-      return _updateOutflow(_ctx, _agreementData, true);
-  }
-
-  function afterAgreementUpdated(
-      ISuperToken _superToken,
-      address _agreementClass,
-      bytes32 ,//_agreementId,
-      bytes calldata _agreementData,
-      bytes calldata ,//_cbdata,
-      bytes calldata _ctx
-  )
-      external override
-      onlyExpected(_superToken, _agreementClass)
-      onlyHost
-      returns (bytes memory newCtx)
-  {
-      if (!_exchange._isInputToken(_superToken) || !_exchange._isCFAv1(_agreementClass)) return _ctx;
-      return _updateOutflow(_ctx, _agreementData, true);
-  }
-
-  function afterAgreementTerminated(
-      ISuperToken _superToken,
-      address _agreementClass,
-      bytes32 ,//_agreementId,
-      bytes calldata _agreementData,
-      bytes calldata ,//_cbdata,
-      bytes calldata _ctx
-  )
-      external override
-      onlyHost
-      returns (bytes memory newCtx)
-  {
-      // According to the app basic law, we should never revert in a termination callback
-      if (!_exchange._isInputToken(_superToken) || !_exchange._isCFAv1(_agreementClass)) return _ctx;
-      // Skip distribution when terminating to avoid reverts
-      return _updateOutflow(_ctx, _agreementData, false);
-  }
-
-
-
-  modifier onlyHost() {
-      require(msg.sender == address(_exchange.host), "one host");
-      _;
-  }
-
-  modifier onlyExpected(ISuperToken superToken, address agreementClass) {
-    if (_exchange._isCFAv1(agreementClass)) {
-      require(_exchange._isInputToken(superToken), "!inputAccepted");
-    } else if (_exchange._isIDAv1(agreementClass)) {
-      require(_exchange._isOutputToken(superToken) || _exchange._isSubsidyToken(superToken), "!outputAccepted");
+    function afterAgreementCreated(
+        ISuperToken _superToken,
+        address _agreementClass,
+        bytes32, // _agreementId,
+        bytes calldata _agreementData,
+        bytes calldata, // _cbdata,
+        bytes calldata _ctx
+    )
+        external
+        override
+        onlyExpected(_superToken, _agreementClass)
+        onlyHost
+        returns (bytes memory newCtx)
+    {
+        if (
+            !_exchange._isInputToken(_superToken) ||
+            !_exchange._isCFAv1(_agreementClass)
+        ) return _ctx;
+        return _updateOutflow(_ctx, _agreementData, true);
     }
-    _;
-  }
 
+    function afterAgreementUpdated(
+        ISuperToken _superToken,
+        address _agreementClass,
+        bytes32, //_agreementId,
+        bytes calldata _agreementData,
+        bytes calldata, //_cbdata,
+        bytes calldata _ctx
+    )
+        external
+        override
+        onlyExpected(_superToken, _agreementClass)
+        onlyHost
+        returns (bytes memory newCtx)
+    {
+        if (
+            !_exchange._isInputToken(_superToken) ||
+            !_exchange._isCFAv1(_agreementClass)
+        ) return _ctx;
+        return _updateOutflow(_ctx, _agreementData, true);
+    }
 
-  }
+    function afterAgreementTerminated(
+        ISuperToken _superToken,
+        address _agreementClass,
+        bytes32, //_agreementId,
+        bytes calldata _agreementData,
+        bytes calldata, //_cbdata,
+        bytes calldata _ctx
+    ) external override onlyHost returns (bytes memory newCtx) {
+        // According to the app basic law, we should never revert in a termination callback
+        if (
+            !_exchange._isInputToken(_superToken) ||
+            !_exchange._isCFAv1(_agreementClass)
+        ) return _ctx;
+        // Skip distribution when terminating to avoid reverts
+        return _updateOutflow(_ctx, _agreementData, false);
+    }
+
+    modifier onlyHost() {
+        require(msg.sender == address(_exchange.host), "one host");
+        _;
+    }
+
+    modifier onlyExpected(ISuperToken superToken, address agreementClass) {
+        if (_exchange._isCFAv1(agreementClass)) {
+            require(_exchange._isInputToken(superToken), "!inputAccepted");
+        } else if (_exchange._isIDAv1(agreementClass)) {
+            require(
+                _exchange._isOutputToken(superToken) ||
+                    _exchange._isSubsidyToken(superToken),
+                "!outputAccepted"
+            );
+        }
+        _;
+    }
+}

--- a/01-Contracts/contracts/StreamExchange.sol
+++ b/01-Contracts/contracts/StreamExchange.sol
@@ -132,6 +132,9 @@ contract StreamExchange is Ownable, SuperAppBase, UsingTellor {
 
     _exchange.streams[requester].rate = _exchange.streams[requester].rate + changeInFlowRate;
 
+    // Make sure the requester has at least 8 hours of balance to stream
+    require(int(_exchange.inputToken.balanceOf(requester)) >= _exchange.streams[requester].rate * 8 hours, "!enoughTokens");
+
     newCtx = _exchange._updateSubscriptionWithContext(newCtx, _exchange.outputIndexId, requester, uint128(uint(int(_exchange.streams[requester].rate))), _exchange.outputToken);
     newCtx = _exchange._updateSubscriptionWithContext(newCtx, _exchange.subsidyIndexId, requester, uint128(uint(int(_exchange.streams[requester].rate))), _exchange.subsidyToken);
 

--- a/01-Contracts/contracts/StreamExchangeHelper.sol
+++ b/01-Contracts/contracts/StreamExchangeHelper.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
-pragma experimental ABIEncoderV2;
+pragma abicoder v2;
 
 import "hardhat/console.sol";
 
@@ -192,8 +192,7 @@ library StreamExchangeHelper {
 
     // Downgrade and scale the input amount
     self.inputToken.downgrade(amount);
-    // Swap on Sushiswap
-    ERC20(inputToken).safeIncreaseAllowance(address(self.sushiRouter), amount);
+    
     self.sushiRouter.swapExactTokensForTokens(
        amount,
        0, // Accept any amount but fail if we're too far from the oracle price
@@ -206,8 +205,6 @@ library StreamExchangeHelper {
     console.log("outputAmount", outputAmount);
     require(outputAmount >= minOutput, "BAD_EXCHANGE_RATE: Try again later");
 
-    // Convert the outputToken back to its supertoken version
-    ERC20(outputToken).safeIncreaseAllowance(address(self.outputToken), outputAmount);
     self.outputToken.upgrade(outputAmount);
 
     return outputAmount;

--- a/01-Contracts/hardhat.config.js
+++ b/01-Contracts/hardhat.config.js
@@ -54,9 +54,9 @@ module.exports = {
           url: process.env.POLYGON_MAINNET_URL,
           blockNumber: 17909209
         },
-        // accounts: {
-        //   mnemonic: process.env.MNEMONIC
-        // }
+        accounts: {
+          mnemonic: process.env.MNEMONIC
+        }
       }
   },
   etherscan: {

--- a/01-Contracts/hardhat.config.js
+++ b/01-Contracts/hardhat.config.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 require("@nomiclabs/hardhat-waffle");
 require("@nomiclabs/hardhat-web3");
 require('@nomiclabs/hardhat-ethers');
@@ -24,30 +25,38 @@ task("accounts", "Prints the list of accounts", async () => {
 module.exports = {
   solidity: "0.8.3",
   mocha: {
-    timeout: 100000
+    timeout: 0
   },
+  defaultNetwork: "hardhat",
   networks: {
-    polygon: {
-      url: "https://polygon-mainnet.infura.io/v3/" + process.env.INFURA_KEY,
-      accounts: [process.env.MATIC_PRIVATE_KEY],
-      gas: 2000000,
-      gasPrice: 20000000000
-    },
-    rinkeby: {
-      url: "https://rinkeby.infura.io/v3/" + process.env.INFURA_KEY,
-      accounts: [process.env.PRIVATE_KEY],
-    },
-    // kovan: {
-    //   url: "https://kovan.infura.io/v3/" + process.env.INFURA_KEY,
-    //   accounts: [process.env.PRIVATE_KEY],
+    // polygon: {
+    //   url: "https://polygon-mainnet.infura.io/v3/" + process.env.INFURA_KEY,
+    //   accounts: [process.env.MATIC_PRIVATE_KEY],
     //   gas: 2000000,
-    //   gasPrice: 2000000000
+    //   gasPrice: 20000000000
     // },
+    // rinkeby: {
+    //   url: "https://rinkeby.infura.io/v3/" + process.env.INFURA_KEY,
+    //   accounts: [process.env.PRIVATE_KEY],
+    // },
+    // // kovan: {
+    // //   url: "https://kovan.infura.io/v3/" + process.env.INFURA_KEY,
+    // //   accounts: [process.env.PRIVATE_KEY],
+    // //   gas: 2000000,
+    // //   gasPrice: 2000000000
+    // // },
     hardhat: {
+        // forking: {
+        //   url: process.env.QUICK_NODE_URL,
+        //   accounts: [process.env.PRIVATE_KEY_ADMIN, process.env.PRIVATE_KEY_ALICE, process.env.PRIVATE_KEY_BOB],
+        // }
         forking: {
-          url: process.env.QUICK_NODE_URL,
-          accounts: [process.env.PRIVATE_KEY_ADMIN, process.env.PRIVATE_KEY_ALICE, process.env.PRIVATE_KEY_BOB],
-        }
+          url: process.env.POLYGON_MAINNET_URL,
+          blockNumber: 17909209
+        },
+        // accounts: {
+        //   mnemonic: process.env.MNEMONIC
+        // }
       }
   },
   etherscan: {

--- a/01-Contracts/hardhat.config.js
+++ b/01-Contracts/hardhat.config.js
@@ -29,30 +29,26 @@ module.exports = {
   },
   defaultNetwork: "hardhat",
   networks: {
-    // polygon: {
-    //   url: "https://polygon-mainnet.infura.io/v3/" + process.env.INFURA_KEY,
-    //   accounts: [process.env.MATIC_PRIVATE_KEY],
-    //   gas: 2000000,
-    //   gasPrice: 20000000000
-    // },
-    // rinkeby: {
-    //   url: "https://rinkeby.infura.io/v3/" + process.env.INFURA_KEY,
+    polygon: {
+      url: "https://polygon-mainnet.infura.io/v3/" + process.env.INFURA_KEY,
+      accounts: [process.env.MATIC_PRIVATE_KEY],
+      gas: 2000000,
+      gasPrice: 20000000000
+    },
+    rinkeby: {
+      url: "https://rinkeby.infura.io/v3/" + process.env.INFURA_KEY,
+      accounts: [process.env.PRIVATE_KEY],
+    },
+    // kovan: {
+    //   url: "https://kovan.infura.io/v3/" + process.env.INFURA_KEY,
     //   accounts: [process.env.PRIVATE_KEY],
+    //   gas: 2000000,
+    //   gasPrice: 2000000000
     // },
-    // // kovan: {
-    // //   url: "https://kovan.infura.io/v3/" + process.env.INFURA_KEY,
-    // //   accounts: [process.env.PRIVATE_KEY],
-    // //   gas: 2000000,
-    // //   gasPrice: 2000000000
-    // // },
     hardhat: {
-        // forking: {
-        //   url: process.env.QUICK_NODE_URL,
-        //   accounts: [process.env.PRIVATE_KEY_ADMIN, process.env.PRIVATE_KEY_ALICE, process.env.PRIVATE_KEY_BOB],
-        // }
         forking: {
           url: process.env.POLYGON_MAINNET_URL,
-          blockNumber: 17909209
+          blockNumber: 17957512
         },
         accounts: {
           mnemonic: process.env.MNEMONIC

--- a/01-Contracts/test/SteamExchange.test.js
+++ b/01-Contracts/test/SteamExchange.test.js
@@ -38,14 +38,14 @@ describe("StreamExchange", () => {
     const TELLOR_REQUEST_ID = 1
     const BOB_ADDRESS = "0x00Ce20EC71942B41F50fF566287B811bbef46DC8"
     const ALICE_ADDRESS = "0x9f348cdD00dcD61EE7917695D2157ef6af2d7b9B"
-    const OWNER_ADDRESS = "0x3226C9EaC0379F04Ba2b1E1e1fcD52ac26309aeA"
+    const OWNER_ADDRESS = "0x452181dAe31Cf9f42189df71eC64298993BEe6d3"
     const SF_REG_KEY = process.env.SF_REG_KEY
     let oraclePrice;
 
-    var appBalances = {ethx: [], daix: [], ric: []}
-    var ownerBalances = {ethx: [], daix: [], ric: []}
-    var aliceBalances = {ethx: [], daix: [], ric: []}
-    var bobBalances = {ethx: [], daix: [], ric: []}
+    var appBalances = { ethx: [], daix: [], ric: [] }
+    var ownerBalances = { ethx: [], daix: [], ric: [] }
+    var aliceBalances = { ethx: [], daix: [], ric: [] }
+    var bobBalances = { ethx: [], daix: [], ric: [] }
 
     before(async function () {
         //process.env.RESET_SUPERFLUID_FRAMEWORK = 1;
@@ -55,32 +55,37 @@ describe("StreamExchange", () => {
     });
 
     beforeEach(async function () {
-      // Admin
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [OWNER_ADDRESS]}
-      )
-      owner = await ethers.provider.getSigner(OWNER_ADDRESS)
-      await deployFramework(errorHandler, {
-          web3,
-          from: owner.address,
-      });
-      // Alice
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [ALICE_ADDRESS]}
-      )
-      alice = await ethers.provider.getSigner(ALICE_ADDRESS)
+        // Admin
+        await hre.network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [OWNER_ADDRESS]
+        }
+        )
+        owner = await ethers.provider.getSigner(OWNER_ADDRESS);
+        
+        // Not required if using mainnet contracts
+        //   await deployFramework(errorHandler, {
+        //       web3,
+        //       from: owner.address,
+        //   });
+        // Alice
+        await hre.network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [ALICE_ADDRESS]
+        }
+        )
+        alice = await ethers.provider.getSigner(ALICE_ADDRESS)
 
-      // Bob
-      await hre.network.provider.request({
-        method: "hardhat_impersonateAccount",
-        params: [BOB_ADDRESS]}
-      )
-      bob = await ethers.provider.getSigner(BOB_ADDRESS)
+        // Bob
+        await hre.network.provider.request({
+            method: "hardhat_impersonateAccount",
+            params: [BOB_ADDRESS]
+        }
+        )
+        bob = await ethers.provider.getSigner(BOB_ADDRESS)
 
 
-        const accounts = [owner, alice, bob] ;
+        const accounts = [owner, alice, bob];
 
 
         sf = new SuperfluidSDK.Framework({
@@ -94,7 +99,7 @@ describe("StreamExchange", () => {
         daix = sf.tokens.DAIx;
 
         for (var i = 0; i < names.length; i++) {
-          console.log(accounts[i]._address)
+            console.log(accounts[i]._address)
             u[names[i].toLowerCase()] = sf.user({
                 address: accounts[i]._address || accounts[i].address,
                 token: ethx.address,
@@ -105,8 +110,8 @@ describe("StreamExchange", () => {
 
         console.log("Owner:", u.admin.address);
         console.log("Host:", sf.host.address);
-        console.log("DAIx: ",daix.address);
-        console.log("ETHx: ",ethx.address);
+        console.log("DAIx: ", daix.address);
+        console.log("ETHx: ", ethx.address);
 
         // NOTE: Assume the oracle is up to date
         // Deploy Tellor Oracle contracts
@@ -126,10 +131,10 @@ describe("StreamExchange", () => {
         let sed = await StreamExchangeHelper.deploy();
 
         const StreamExchange = await ethers.getContractFactory("StreamExchange", {
-          libraries: {
-            StreamExchangeHelper: sed.address,
-          },
-          signer: owner
+            libraries: {
+                StreamExchangeHelper: sed.address,
+            },
+            signer: owner
         });
 
         const ERC20 = await ethers.getContractFactory("ERC20");
@@ -146,15 +151,15 @@ describe("StreamExchange", () => {
         console.log("DAIx", daix.address)
         console.log("ETHx", ethx.address)
         app = await StreamExchange.deploy(sf.host.address,
-                                          sf.agreements.cfa.address,
-                                          sf.agreements.ida.address,
-                                          ethx.address,
-                                          daix.address,
-                                          RIC_TOKEN_ADDRESS,
-                                          SUSHISWAP_ROUTER_ADDRESS, //sr.address,
-                                          TELLOR_ORACLE_ADDRESS,
-                                          TELLOR_REQUEST_ID,
-                                          SF_REG_KEY);
+            sf.agreements.cfa.address,
+            sf.agreements.ida.address,
+            ethx.address,
+            daix.address,
+            RIC_TOKEN_ADDRESS,
+            SUSHISWAP_ROUTER_ADDRESS, //sr.address,
+            TELLOR_ORACLE_ADDRESS,
+            TELLOR_REQUEST_ID,
+            SF_REG_KEY);
         console.log("Deployed")
         console.log(await ric.balanceOf(u.admin.address))
         // await ric.transfer(app.address, "1000000000000000000000000")
@@ -316,173 +321,173 @@ describe("StreamExchange", () => {
     }
 
     async function subscribe(user) {
-      // Alice approves a subscription to the app
-      console.log(sf.host.callAgreement)
-      console.log(sf.agreements.ida.address)
-      console.log(usdcx.address)
-      console.log(app.address)
-      await web3tx(
-          sf.host.callAgreement,
-          "user approves subscription to the app"
-      )(
-          sf.agreements.ida.address,
-          sf.agreements.ida.contract.methods
-              .approveSubscription(ethx.address, app.address, 0, "0x")
-              .encodeABI(),
-          "0x", // user data
-          {
-              from: user
-          }
-      );
+        // Alice approves a subscription to the app
+        console.log(sf.host.callAgreement)
+        console.log(sf.agreements.ida.address)
+        console.log(usdcx.address)
+        console.log(app.address)
+        await web3tx(
+            sf.host.callAgreement,
+            "user approves subscription to the app"
+        )(
+            sf.agreements.ida.address,
+            sf.agreements.ida.contract.methods
+                .approveSubscription(ethx.address, app.address, 0, "0x")
+                .encodeABI(),
+            "0x", // user data
+            {
+                from: user
+            }
+        );
 
 
     }
 
     async function delta(account, balances) {
-      let len = balances.ethx.length
-      let changeInEth = balances.ethx[len-1] - balances.ethx[len-2]
-      let changeInDai = balances.daix[len-1] - balances.daix[len-2]
-      console.log()
-      console.log("Change in balances for ", account)
-      console.log("Ethx:", changeInEth, "Bal:", balances.ethx[len-1])
-      console.log("Daix:", changeInDai, "Bal:", balances.daix[len-1])
-      console.log("Exchange Rate:", changeInDai/changeInEth)
+        let len = balances.ethx.length
+        let changeInEth = balances.ethx[len - 1] - balances.ethx[len - 2]
+        let changeInDai = balances.daix[len - 1] - balances.daix[len - 2]
+        console.log()
+        console.log("Change in balances for ", account)
+        console.log("Ethx:", changeInEth, "Bal:", balances.ethx[len - 1])
+        console.log("Daix:", changeInDai, "Bal:", balances.daix[len - 1])
+        console.log("Exchange Rate:", changeInDai / changeInEth)
     }
 
     async function takeMeasurements() {
-      appBalances.ethx.push((await ethx.balanceOf(app.address)).toString());
-      ownerBalances.ethx.push((await ethx.balanceOf(u.admin.address)).toString());
-      aliceBalances.ethx.push((await ethx.balanceOf(u.alice.address)).toString());
-      bobBalances.ethx.push((await ethx.balanceOf(u.bob.address)).toString());
+        appBalances.ethx.push((await ethx.balanceOf(app.address)).toString());
+        ownerBalances.ethx.push((await ethx.balanceOf(u.admin.address)).toString());
+        aliceBalances.ethx.push((await ethx.balanceOf(u.alice.address)).toString());
+        bobBalances.ethx.push((await ethx.balanceOf(u.bob.address)).toString());
 
-      appBalances.daix.push((await daix.balanceOf(app.address)).toString());
-      ownerBalances.daix.push((await daix.balanceOf(u.admin.address)).toString());
-      aliceBalances.daix.push((await daix.balanceOf(u.alice.address)).toString());
-      bobBalances.daix.push((await daix.balanceOf(u.bob.address)).toString());
+        appBalances.daix.push((await daix.balanceOf(app.address)).toString());
+        ownerBalances.daix.push((await daix.balanceOf(u.admin.address)).toString());
+        aliceBalances.daix.push((await daix.balanceOf(u.alice.address)).toString());
+        bobBalances.daix.push((await daix.balanceOf(u.bob.address)).toString());
 
-      appBalances.ric.push((await ric.balanceOf(app.address)).toString());
-      ownerBalances.ric.push((await ric.balanceOf(u.admin.address)).toString());
-      aliceBalances.ric.push((await ric.balanceOf(u.alice.address)).toString());
-      bobBalances.ric.push((await ric.balanceOf(u.bob.address)).toString());
+        appBalances.ric.push((await ric.balanceOf(app.address)).toString());
+        ownerBalances.ric.push((await ric.balanceOf(u.admin.address)).toString());
+        aliceBalances.ric.push((await ric.balanceOf(u.alice.address)).toString());
+        bobBalances.ric.push((await ric.balanceOf(u.bob.address)).toString());
     }
 
 
     describe("Stream Exchange", async function () {
-      this.timeout(100000);
+        this.timeout(100000);
 
-      it("should distribute tokens to streamers correctly", async function() {
+        it("should distribute tokens to streamers correctly", async function () {
 
-        // Check setup
-        expect(await app.isAppJailed()).to.equal(false)
-        expect(await app.getInputToken()).to.equal(ethx.address)
-        expect(await app.getOuputToken()).to.equal(daix.address)
-        expect(await app.getOuputIndexId()).to.equal(0)
-        expect(await app.getSubsidyToken()).to.equal(ric.address)
-        expect(await app.getSubsidyIndexId()).to.equal(1)
-        expect(await app.getSubsidyRate()).to.equal("400000000000000000")
-        expect(await app.getTotalInflow()).to.equal(0)
-        // expect(await app.getLastDistributionAt()).to.equal()
-        expect(await app.getSushiRouter()).to.equal(SUSHISWAP_ROUTER_ADDRESS)
-        expect(await app.getTellorOracle()).to.equal(TELLOR_ORACLE_ADDRESS)
-        expect(await app.getRequestId()).to.equal(1)
-        expect(await app.getOwner()).to.equal(u.admin.address)
-        expect(await app.getFeeRate()).to.equal(20000)
+            // Check setup
+            expect(await app.isAppJailed()).to.equal(false)
+            expect(await app.getInputToken()).to.equal(ethx.address)
+            expect(await app.getOuputToken()).to.equal(daix.address)
+            expect(await app.getOuputIndexId()).to.equal(0)
+            expect(await app.getSubsidyToken()).to.equal(ric.address)
+            expect(await app.getSubsidyIndexId()).to.equal(1)
+            expect(await app.getSubsidyRate()).to.equal("400000000000000000")
+            expect(await app.getTotalInflow()).to.equal(0)
+            // expect(await app.getLastDistributionAt()).to.equal()
+            expect(await app.getSushiRouter()).to.equal(SUSHISWAP_ROUTER_ADDRESS)
+            expect(await app.getTellorOracle()).to.equal(TELLOR_ORACLE_ADDRESS)
+            expect(await app.getRequestId()).to.equal(1)
+            expect(await app.getOwner()).to.equal(u.admin.address)
+            expect(await app.getFeeRate()).to.equal(20000)
 
-        await app.connect(owner).setFeeRate(20000);
-        await app.connect(owner).setRateTolerance(50000);
-        await app.connect(owner).setSubsidyRate("500000000000000000")
+            await app.connect(owner).setFeeRate(20000);
+            await app.connect(owner).setRateTolerance(50000);
+            await app.connect(owner).setSubsidyRate("500000000000000000")
 
-        expect(await app.getSubsidyRate()).to.equal("500000000000000000")
-        expect(await app.getFeeRate()).to.equal(20000)
-        expect(await app.getRateTolerance()).to.equal(50000)
-        console.log("Getters and setters correct")
+            expect(await app.getSubsidyRate()).to.equal("500000000000000000")
+            expect(await app.getFeeRate()).to.equal(20000)
+            expect(await app.getRateTolerance()).to.equal(50000)
+            console.log("Getters and setters correct")
 
-        const inflowRate = toWad(0.000000100);
+            const inflowRate = toWad(0.000000100);
 
-        console.log("Transfer bob")
-        await ethx.transfer(u.bob.address, "7000000000000000", {from: u.admin.address});
-        console.log("Transfer aliuce")
-        await ethx.transfer(u.alice.address, "7000000000000000", {from: u.admin.address});
-        console.log("Done")
+            console.log("Transfer bob")
+            await ethx.transfer(u.bob.address, "7000000000000000", { from: u.admin.address });
+            console.log("Transfer aliuce")
+            await ethx.transfer(u.alice.address, "7000000000000000", { from: u.admin.address });
+            console.log("Done")
 
-        await tp.submitValue(1, oraclePrice);
+            await tp.submitValue(1, oraclePrice);
 
-        await takeMeasurements();
+            await takeMeasurements();
 
-        // Test owner start/stop stream
-        await u.admin.flow({ flowRate: inflowRate, recipient: u.app });
-        await traveler.advanceTimeAndBlock(60*60*3);
-        await tp.submitValue(1, oraclePrice);
-        await app.distribute()
-        await u.admin.flow({ flowRate: "0", recipient: u.app });
-
-
-
-        await u.bob.flow({ flowRate: inflowRate, recipient: u.app });
-        await traveler.advanceTimeAndBlock(60*60*3);
-        await tp.submitValue(1, oraclePrice);
-        await app.distribute()
-        await takeMeasurements();
-        await delta("Bob", bobBalances)
-        await delta("Alice", aliceBalances)
-        await delta("Owner", ownerBalances)
-
-        // Round 2
-        await u.alice.flow({ flowRate: inflowRate, recipient: u.app });
-        await traveler.advanceTimeAndBlock(60*60*2);
-        await tp.submitValue(1, oraclePrice);
-        await app.distribute()
-        await takeMeasurements()
-        await delta("Bob", bobBalances)
-        await delta("Alice", aliceBalances)
-        await delta("Owner", ownerBalances)
-
-
-        // Round 3
-        await traveler.advanceTimeAndBlock(60*60*2);
-        await tp.submitValue(1, oraclePrice);
-        await app.distribute()
-        await takeMeasurements()
-        await delta("Bob", bobBalances)
-        await delta("Alice", aliceBalances)
-        await delta("Owner", ownerBalances)
-
-        // Try close stream and expect revert
-        await expect(
-         app.closeStream(u.bob.address)
-       ).to.be.revertedWith("!closable");
-
-        // Round 4
-        // await u.alice.flow({ flowRate: "0", recipient: u.app });
-        await traveler.advanceTimeAndBlock(60*60*3);
-        await tp.submitValue(1, oraclePrice);
-        await app.distribute()
-        await takeMeasurements()
-        await delta("Bob", bobBalances)
-        await delta("Alice", aliceBalances)
-        await delta("Owner", ownerBalances)
-
-        // Try to close bobs stream
-        await app.closeStream(u.bob.address);
-        // Verify its closed and cleaned up
-        expect(await app.getStreamRate(u.bob.address)).to.equal("0")
-        expect((await app.getIDAShares(0, u.bob.address)).toString()).to.equal("true,true,0,0")
-        expect((await app.getIDAShares(1, u.bob.address)).toString()).to.equal("true,true,0,0")
-
-
-        // Round 5 - Run them empty and close with keeper
-        await traveler.advanceTimeAndBlock(60*60*2);
-        await tp.submitValue(1, oraclePrice);
-        await app.distribute()
-        await takeMeasurements()
-        await delta("Bob", bobBalances)
-        await delta("Alice", aliceBalances)
-        await delta("Owner", ownerBalances)
+            // Test owner start/stop stream
+            await u.admin.flow({ flowRate: inflowRate, recipient: u.app });
+            await traveler.advanceTimeAndBlock(60 * 60 * 3);
+            await tp.submitValue(1, oraclePrice);
+            await app.distribute()
+            await u.admin.flow({ flowRate: "0", recipient: u.app });
 
 
 
-      });
+            await u.bob.flow({ flowRate: inflowRate, recipient: u.app });
+            await traveler.advanceTimeAndBlock(60 * 60 * 3);
+            await tp.submitValue(1, oraclePrice);
+            await app.distribute()
+            await takeMeasurements();
+            await delta("Bob", bobBalances)
+            await delta("Alice", aliceBalances)
+            await delta("Owner", ownerBalances)
 
-  });
+            // Round 2
+            await u.alice.flow({ flowRate: inflowRate, recipient: u.app });
+            await traveler.advanceTimeAndBlock(60 * 60 * 2);
+            await tp.submitValue(1, oraclePrice);
+            await app.distribute()
+            await takeMeasurements()
+            await delta("Bob", bobBalances)
+            await delta("Alice", aliceBalances)
+            await delta("Owner", ownerBalances)
+
+
+            // Round 3
+            await traveler.advanceTimeAndBlock(60 * 60 * 2);
+            await tp.submitValue(1, oraclePrice);
+            await app.distribute()
+            await takeMeasurements()
+            await delta("Bob", bobBalances)
+            await delta("Alice", aliceBalances)
+            await delta("Owner", ownerBalances)
+
+            // Try close stream and expect revert
+            await expect(
+                app.closeStream(u.bob.address)
+            ).to.be.revertedWith("!closable");
+
+            // Round 4
+            // await u.alice.flow({ flowRate: "0", recipient: u.app });
+            await traveler.advanceTimeAndBlock(60 * 60 * 3);
+            await tp.submitValue(1, oraclePrice);
+            await app.distribute()
+            await takeMeasurements()
+            await delta("Bob", bobBalances)
+            await delta("Alice", aliceBalances)
+            await delta("Owner", ownerBalances)
+
+            // Try to close bobs stream
+            await app.closeStream(u.bob.address);
+            // Verify its closed and cleaned up
+            expect(await app.getStreamRate(u.bob.address)).to.equal("0")
+            expect((await app.getIDAShares(0, u.bob.address)).toString()).to.equal("true,true,0,0")
+            expect((await app.getIDAShares(1, u.bob.address)).toString()).to.equal("true,true,0,0")
+
+
+            // Round 5 - Run them empty and close with keeper
+            await traveler.advanceTimeAndBlock(60 * 60 * 2);
+            await tp.submitValue(1, oraclePrice);
+            await app.distribute()
+            await takeMeasurements()
+            await delta("Bob", bobBalances)
+            await delta("Alice", aliceBalances)
+            await delta("Owner", ownerBalances)
+
+
+
+        });
+
+    });
 
 });

--- a/01-Contracts/test/SteamExchange.test.js
+++ b/01-Contracts/test/SteamExchange.test.js
@@ -42,10 +42,10 @@ describe("StreamExchange", () => {
     const SF_REG_KEY = process.env.SF_REG_KEY
     let oraclePrice;
 
-    var appBalances = { ethx: [], daix: [], ric: [] }
-    var ownerBalances = { ethx: [], daix: [], ric: [] }
-    var aliceBalances = { ethx: [], daix: [], ric: [] }
-    var bobBalances = { ethx: [], daix: [], ric: [] }
+    var appBalances = { ethx: [], daix: [], usdcx: [], ric: [] }
+    var ownerBalances = { ethx: [], daix: [], usdcx: [], ric: [] }
+    var aliceBalances = { ethx: [], daix: [], usdcx: [], ric: [] }
+    var bobBalances = { ethx: [], daix: [], usdcx: [], ric: [] }
 
     before(async function () {
         //process.env.RESET_SUPERFLUID_FRAMEWORK = 1;
@@ -62,7 +62,7 @@ describe("StreamExchange", () => {
         }
         )
         owner = await ethers.provider.getSigner(OWNER_ADDRESS);
-        
+
         // Not required if using mainnet contracts
         //   await deployFramework(errorHandler, {
         //       web3,
@@ -91,18 +91,19 @@ describe("StreamExchange", () => {
         sf = new SuperfluidSDK.Framework({
             web3,
             resolverAddress: "0xE0cc76334405EE8b39213E620587d815967af39C",
-            tokens: ["DAI", "ETH"],
+            tokens: ["DAI", "USDC", "ETH"],
             version: "v1"
         });
         await sf.initialize();
         ethx = sf.tokens.ETHx;
         daix = sf.tokens.DAIx;
+        usdcx = sf.tokens.USDCx;
 
         for (var i = 0; i < names.length; i++) {
             console.log(accounts[i]._address)
             u[names[i].toLowerCase()] = sf.user({
                 address: accounts[i]._address || accounts[i].address,
-                token: ethx.address,
+                token: usdcx.address,
             });
             u[names[i].toLowerCase()].alias = names[i];
             aliases[u[names[i].toLowerCase()].address] = names[i];
@@ -111,21 +112,13 @@ describe("StreamExchange", () => {
         console.log("Owner:", u.admin.address);
         console.log("Host:", sf.host.address);
         console.log("DAIx: ", daix.address);
+        console.log("USDCx: ", usdcx.address);
         console.log("ETHx: ", ethx.address);
 
         // NOTE: Assume the oracle is up to date
         // Deploy Tellor Oracle contracts
         const TellorPlayground = await ethers.getContractFactory("TellorPlayground");
         tp = await TellorPlayground.attach(TELLOR_ORACLE_ADDRESS);
-        //
-        // await tp.submitValue(1, 1050000);
-
-        // const UsingTellor = await ethers.getContractFactory("UsingTellor");
-        // usingTellor = await UsingTellor.deploy(tp.address);
-
-        // Mocking Sushiswap Router
-        // const MockUniswapRouter = await ethers.getContractFactory("MockUniswapRouter");
-        // sr = await MockUniswapRouter.deploy(tp.address, 1, dai.address);
 
         const StreamExchangeHelper = await ethers.getContractFactory("StreamExchangeHelper");
         let sed = await StreamExchangeHelper.deploy();
@@ -153,8 +146,8 @@ describe("StreamExchange", () => {
         app = await StreamExchange.deploy(sf.host.address,
             sf.agreements.cfa.address,
             sf.agreements.ida.address,
+            usdcx.address,
             ethx.address,
-            daix.address,
             RIC_TOKEN_ADDRESS,
             SUSHISWAP_ROUTER_ADDRESS, //sr.address,
             TELLOR_ORACLE_ADDRESS,
@@ -170,89 +163,33 @@ describe("StreamExchange", () => {
 
         // Do approvals
         // Already approved?
-        await web3tx(
-            sf.host.callAgreement,
-            "Alice approves subscription to the app"
-        )(
-            sf.agreements.ida.address,
-            sf.agreements.ida.contract.methods
-                .approveSubscription(daix.address, app.address, 0, "0x")
-                .encodeABI(),
-            "0x", // user data
-            {
-                from: u.alice.address
-            }
-        );
-        await web3tx(
-            sf.host.callAgreement,
-            "Bob approves subscription to the app"
-        )(
-            sf.agreements.ida.address,
-            sf.agreements.ida.contract.methods
-                .approveSubscription(daix.address, app.address, 0, "0x")
-                .encodeABI(),
-            "0x", // user data
-            {
-                from: u.bob.address
-            }
-        );
 
-        await web3tx(
-            sf.host.callAgreement,
-            "Admin approves subscription to the app"
-        )(
-            sf.agreements.ida.address,
-            sf.agreements.ida.contract.methods
-                .approveSubscription(daix.address, app.address, 0, "0x")
-                .encodeABI(),
-            "0x", // user data
-            {
-                from: u.admin.address
-            }
-        );
+        let tokens = [ethx.address, ricAddress]
+        let users = [u.alice.address, u.bob.address, u.admin.address]
 
-        // Do approvals
-        // Already approved?
-        await web3tx(
-            sf.host.callAgreement,
-            "Alice approves subscription to the app"
-        )(
-            sf.agreements.ida.address,
-            sf.agreements.ida.contract.methods
-                .approveSubscription(ricAddress, app.address, 1, "0x")
-                .encodeABI(),
-            "0x", // user data
-            {
-                from: u.alice.address
-            }
-        );
-        await web3tx(
-            sf.host.callAgreement,
-            "Bob approves subscription to the app"
-        )(
-            sf.agreements.ida.address,
-            sf.agreements.ida.contract.methods
-                .approveSubscription(ricAddress, app.address, 1, "0x")
-                .encodeABI(),
-            "0x", // user data
-            {
-                from: u.bob.address
-            }
-        );
+        for (let t = 0; t < tokens.length; t++) {
+            for (let u = 0; u < users.length; u++) {
+                let index = 0
+                if (tokens[t] == ricAddress) {
+                    index = 1
+                }
 
-        await web3tx(
-            sf.host.callAgreement,
-            "Admin approves subscription to the app"
-        )(
-            sf.agreements.ida.address,
-            sf.agreements.ida.contract.methods
-                .approveSubscription(ricAddress, app.address, 1, "0x")
-                .encodeABI(),
-            "0x", // user data
-            {
-                from: u.admin.address
+                await web3tx(
+                    sf.host.callAgreement,
+                    users[u] + " approves subscription to the app"
+                )(
+                    sf.agreements.ida.address,
+                    sf.agreements.ida.contract.methods
+                        .approveSubscription(tokens[t], app.address, t, "0x")
+                        .encodeABI(),
+                    "0x", // user data
+                    {
+                        from: users[u]
+                    }
+                );
             }
-        );
+        }
+
     });
 
     async function checkBalance(user) {
@@ -345,13 +282,13 @@ describe("StreamExchange", () => {
 
     async function delta(account, balances) {
         let len = balances.ethx.length
-        let changeInEth = balances.ethx[len - 1] - balances.ethx[len - 2]
-        let changeInDai = balances.daix[len - 1] - balances.daix[len - 2]
+        let changeInInToken = balances.ethx[len - 1] - balances.ethx[len - 2]
+        let changeInOutToken = balances.usdcx[len - 1] - balances.usdcx[len - 2]
         console.log()
         console.log("Change in balances for ", account)
-        console.log("Ethx:", changeInEth, "Bal:", balances.ethx[len - 1])
-        console.log("Daix:", changeInDai, "Bal:", balances.daix[len - 1])
-        console.log("Exchange Rate:", changeInDai / changeInEth)
+        console.log("Ethx:", changeInInToken, "Bal:", balances.ethx[len - 1])
+        console.log("Usdcx:", changeInOutToken, "Bal:", balances.usdcx[len - 1])
+        console.log("Exchange Rate:", changeInOutToken / changeInInToken)
     }
 
     async function takeMeasurements() {
@@ -360,10 +297,10 @@ describe("StreamExchange", () => {
         aliceBalances.ethx.push((await ethx.balanceOf(u.alice.address)).toString());
         bobBalances.ethx.push((await ethx.balanceOf(u.bob.address)).toString());
 
-        appBalances.daix.push((await daix.balanceOf(app.address)).toString());
-        ownerBalances.daix.push((await daix.balanceOf(u.admin.address)).toString());
-        aliceBalances.daix.push((await daix.balanceOf(u.alice.address)).toString());
-        bobBalances.daix.push((await daix.balanceOf(u.bob.address)).toString());
+        appBalances.usdcx.push((await usdcx.balanceOf(app.address)).toString());
+        ownerBalances.usdcx.push((await usdcx.balanceOf(u.admin.address)).toString());
+        aliceBalances.usdcx.push((await usdcx.balanceOf(u.alice.address)).toString());
+        bobBalances.usdcx.push((await usdcx.balanceOf(u.bob.address)).toString());
 
         appBalances.ric.push((await ric.balanceOf(app.address)).toString());
         ownerBalances.ric.push((await ric.balanceOf(u.admin.address)).toString());
@@ -379,8 +316,8 @@ describe("StreamExchange", () => {
 
             // Check setup
             expect(await app.isAppJailed()).to.equal(false)
-            expect(await app.getInputToken()).to.equal(ethx.address)
-            expect(await app.getOuputToken()).to.equal(daix.address)
+            expect(await app.getInputToken()).to.equal(usdcx.address)
+            expect(await app.getOuputToken()).to.equal(ethx.address)
             expect(await app.getOuputIndexId()).to.equal(0)
             expect(await app.getSubsidyToken()).to.equal(ric.address)
             expect(await app.getSubsidyIndexId()).to.equal(1)
@@ -402,12 +339,13 @@ describe("StreamExchange", () => {
             expect(await app.getRateTolerance()).to.equal(50000)
             console.log("Getters and setters correct")
 
-            const inflowRate = toWad(0.000000100);
+            const inflowRateDecimal = 0.0008
+            const inflowRate = toWad(inflowRateDecimal);
 
             console.log("Transfer bob")
-            await ethx.transfer(u.bob.address, "7000000000000000", { from: u.admin.address });
+            await usdcx.transfer(u.bob.address, toWad(50), { from: u.admin.address });
             console.log("Transfer aliuce")
-            await ethx.transfer(u.alice.address, "7000000000000000", { from: u.admin.address });
+            await usdcx.transfer(u.alice.address, toWad(50), { from: u.admin.address });
             console.log("Done")
 
             await tp.submitValue(1, oraclePrice);
@@ -415,8 +353,12 @@ describe("StreamExchange", () => {
             await takeMeasurements();
 
             // Test owner start/stop stream
+            // Try close stream and expect revert
+            await expect(
+                u.admin.flow({ flowRate: toWad(10000), recipient: u.app })
+            ).to.be.revertedWith("!enoughTokens");
             await u.admin.flow({ flowRate: inflowRate, recipient: u.app });
-            await traveler.advanceTimeAndBlock(60 * 60 * 3);
+            await traveler.advanceTimeAndBlock(60 * 60 * 1);
             await tp.submitValue(1, oraclePrice);
             await app.distribute()
             await u.admin.flow({ flowRate: "0", recipient: u.app });
@@ -424,7 +366,7 @@ describe("StreamExchange", () => {
 
 
             await u.bob.flow({ flowRate: inflowRate, recipient: u.app });
-            await traveler.advanceTimeAndBlock(60 * 60 * 3);
+            await traveler.advanceTimeAndBlock(60 * 60 * 1);
             await tp.submitValue(1, oraclePrice);
             await app.distribute()
             await takeMeasurements();
@@ -434,7 +376,7 @@ describe("StreamExchange", () => {
 
             // Round 2
             await u.alice.flow({ flowRate: inflowRate, recipient: u.app });
-            await traveler.advanceTimeAndBlock(60 * 60 * 2);
+            await traveler.advanceTimeAndBlock(60 * 60 * 1);
             await tp.submitValue(1, oraclePrice);
             await app.distribute()
             await takeMeasurements()
@@ -444,7 +386,7 @@ describe("StreamExchange", () => {
 
 
             // Round 3
-            await traveler.advanceTimeAndBlock(60 * 60 * 2);
+            await traveler.advanceTimeAndBlock(60 * 60 * 1);
             await tp.submitValue(1, oraclePrice);
             await app.distribute()
             await takeMeasurements()
@@ -459,13 +401,15 @@ describe("StreamExchange", () => {
 
             // Round 4
             // await u.alice.flow({ flowRate: "0", recipient: u.app });
-            await traveler.advanceTimeAndBlock(60 * 60 * 3);
-            await tp.submitValue(1, oraclePrice);
-            await app.distribute()
-            await takeMeasurements()
-            await delta("Bob", bobBalances)
-            await delta("Alice", aliceBalances)
-            await delta("Owner", ownerBalances)
+            while ((await usdcx.balanceOf(u.bob.address)) > inflowRateDecimal * 60 * 60 * 8 * 1e18) {
+                await traveler.advanceTimeAndBlock(60 * 60 * 2);
+                await tp.submitValue(1, oraclePrice);
+                await app.distribute()
+                await takeMeasurements()
+                await delta("Bob", bobBalances)
+                await delta("Alice", aliceBalances)
+                await delta("Owner", ownerBalances)
+            }
 
             // Try to close bobs stream
             await app.closeStream(u.bob.address);
@@ -476,7 +420,7 @@ describe("StreamExchange", () => {
 
 
             // Round 5 - Run them empty and close with keeper
-            await traveler.advanceTimeAndBlock(60 * 60 * 2);
+            await traveler.advanceTimeAndBlock(60 * 60 * 1);
             await tp.submitValue(1, oraclePrice);
             await app.distribute()
             await takeMeasurements()


### PR DESCRIPTION
Added code in `StreamExchange.sol` and `StreamExchangeHelper.sol` to support unlimited approval of input and output tokens. There are few changes I made to be able to make the above mentioned changes.

- Introduced new variables and lines of code in `SteamExchange.test.js`. This allowed me to write the necessary testing code.
- Changed the statements `pragma experimental ABIEncoderV2` in both `StreamExchange.sol` and `StreamExchangeHelper.sol` to `pragma abicoder v2` as the earlier statement is now deprecated.
- Installed `dotenv` package for using env variables inside `hardhat.config.js` file and test files. Later on useful for using env variables in deploy and task scripts.
- Changed the configurations for hardhat forking in `hardhat.config.js`. This would allow users (testers/contributors) in future to use their own node API URL (I use Alchemy node API). Also, accounts can be derived from secret phrase.

