### PR TITLE
Created tasks for issue#15 (deployment scripts)

### DIFF
--- a/01-Contracts/tasks/DeployPolygon.js
+++ b/01-Contracts/tasks/DeployPolygon.js
@@ -1,0 +1,73 @@
+task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
+    .addParam("input", "Input token address")
+    .addParam("output", "Output token address")
+    .addParam("router", "Router address (UniswapV2 type router) for swapping")
+    .addParam("oracle", "Oracle address for the tokens")
+    .addParam("requestid", "Request ID for Tellor oracle")
+    .addParam("key", "Superfluid registeration key")
+    .setAction(async (taskArgs, hre) => {
+        const { deploy } = deployments;
+        const [deployer] = await ethers.getSigners();
+
+        // Polygon mainnet addresses
+        const HOST_ADDRESS = "0x3E14dC1b13c488a8d5D310918780c983bD5982E7";
+        const CFA_ADDRESS = "0x6EeE6060f715257b970700bc2656De21dEdF074C";
+        const IDA_ADDRESS = "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1";
+        const RIC_CONTRACT_ADDRESS = "0x263026e7e53dbfdce5ae55ade22493f828922965";
+
+        const streamExchangeHelper = await deploy("StreamExchangeHelper", {
+            from: deployer.address,
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        const streamExchange = await deploy("StreamExchange", {
+            from: deployer.address,
+            args: [
+                HOST_ADDRESS,
+                CFA_ADDRESS,
+                IDA_ADDRESS,
+                taskArgs.input,
+                taskArgs.output,
+                RIC_CONTRACT_ADDRESS,
+                taskArgs.router,
+                taskArgs.oracle,
+                taskArgs.requestid,
+                taskArgs.key
+            ],
+            libraries: {
+                StreamExchangeHelper: streamExchangeHelper.address
+            },
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        console.log("Deployed StreamExchangeHelper at: ", streamExchangeHelper.address);
+        console.log("Deployed StreamExchange at: ", streamExchange.address);
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchangeHelper.address
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchangeHelper at address ${streamExchangeHelper.address}`);
+        }
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchange.address,
+                constructorArguments: [
+                    HOST_ADDRESS,
+                    CFA_ADDRESS,
+                    IDA_ADDRESS,
+                    taskArgs.input,
+                    taskArgs.output,
+                    RIC_CONTRACT_ADDRESS,
+                    taskArgs.router,
+                    taskArgs.oracle,
+                    taskArgs.requestid,
+                    taskArgs.key
+                ]
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchange at address ${streamExchange.address}`);
+        }
+    });

--- a/01-Contracts/tasks/DeployRinkeby.js
+++ b/01-Contracts/tasks/DeployRinkeby.js
@@ -1,0 +1,73 @@
+task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
+    .addParam("input", "Input token address")
+    .addParam("output", "Output token address")
+    .addParam("router", "Router address (UniswapV2 type router) for swapping")
+    .addParam("oracle", "Oracle address for the tokens")
+    .addParam("requestid", "Request ID for Tellor oracle")
+    .setAction(async (taskArgs, hre) => {
+        const { deploy } = deployments;
+        const [deployer] = await ethers.getSigners();
+
+        // Rinkeby testnet addresses
+        const HOST_ADDRESS = "0xeD5B5b32110c3Ded02a07c8b8e97513FAfb883B6";
+        const CFA_ADDRESS = "0xF4C5310E51F6079F601a5fb7120bC72a70b96e2A";
+        const IDA_ADDRESS = "0x32E0ecb72C1dDD92B007405F8102c1556624264D";
+        const RIC_CONTRACT_ADDRESS = "0x369A77c1A8A38488cc28C2FaF81D2378B9321D8B";
+
+
+        const streamExchangeHelper = await deploy("StreamExchangeHelper", {
+            from: deployer.address,
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        const streamExchange = await deploy("StreamExchange", {
+            from: deployer.address,
+            args: [
+                HOST_ADDRESS,
+                CFA_ADDRESS,
+                IDA_ADDRESS,
+                taskArgs.input,
+                taskArgs.output,
+                RIC_CONTRACT_ADDRESS,
+                taskArgs.router,
+                taskArgs.oracle,
+                taskArgs.requestid,
+                ""
+            ],
+            libraries: {
+                StreamExchangeHelper: streamExchangeHelper.address
+            },
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        console.log("Deployed StreamExchangeHelper at: ", streamExchangeHelper.address);
+        console.log("Deployed StreamExchange at: ", streamExchange.address);
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchangeHelper.address
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchangeHelper at address ${streamExchangeHelper.address}`);
+        }
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchange.address,
+                constructorArguments: [
+                    HOST_ADDRESS,
+                    CFA_ADDRESS,
+                    IDA_ADDRESS,
+                    taskArgs.input,
+                    taskArgs.output,
+                    RIC_CONTRACT_ADDRESS,
+                    taskArgs.router,
+                    taskArgs.oracle,
+                    taskArgs.requestid,
+                    ""
+                ]
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchange at address ${streamExchange.address}`);
+        }
+    });


### PR DESCRIPTION
This PR is for issue #15 . The issue requested for creating deployment scripts but after further exploration, I found that creating tasks for deploying contracts is more suitable as tasks allow us to pass arguments from CLI. I am only making the PR for 2 files (the task files) but in order to use the tasks, I had to change the format of hardhat.config.js. The following paragraphs would detail the same.

1) Create a tasks folder in the contracts directory and include the tasks files in that folder (if not already done).

2) To use the tasks, you have to import them into the hardhat.config.js file in the following manner:
```
require('./tasks/DeployRinkeby');
require('./tasks/DeployPolygon');
```

3) Also, to use these tasks, one has to install the following packages:

```
@nomiclabs/hardhat-etherscan
hardhat-deploy-ethers
```

When installing `hardhat-deploy-ethers` make sure that you use the following command:
 
`npm install --save-dev @nomiclabs/hardhat-ethers@npm:hardhat-deploy-ethers ethers`

4) Import the packages by including the following lines into hardhat.config.js:

```
require('hardhat-deploy');
require('@nomiclabs/hardhat-etherscan');
```

5) Finally, to run the tasks, see the example code given below:

`hh DeployRinkeby --input 0x0F1D7C55A2B133E000eA10EeC03c774e0d6796e8 --output 0x745861AeD1EEe363b4AaA5F1994Be40b1e05Ff90 --router 0x1b02dA8Cb0d097eB8D57A175b88c7D8b47997506 --oracle 0xA0c5d95ec359f4A33371a06C23D89BA6Fc591A97 --requestid 1 --network rinkeby `

I believe @mikeghen this should be enough for the tasks to work. Ping me if any other errors pop up.