### PR TITLE
Converted scripts to tasks (issue#14 and issue#15)

### DIFF
--- a/01-Contracts/tasks/DeployPolygon.js
+++ b/01-Contracts/tasks/DeployPolygon.js
@@ -1,0 +1,73 @@
+task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
+    .addParam("input", "Input token address")
+    .addParam("output", "Output token address")
+    .addParam("router", "Router address (UniswapV2 type router) for swapping")
+    .addParam("oracle", "Oracle address for the tokens")
+    .addParam("requestid", "Request ID for Tellor oracle")
+    .addParam("key", "Superfluid registeration key")
+    .setAction(async (taskArgs, hre) => {
+        const { deploy } = deployments;
+        const [deployer] = await ethers.getSigners();
+
+        // Polygon mainnet addresses
+        const HOST_ADDRESS = "0x3E14dC1b13c488a8d5D310918780c983bD5982E7";
+        const CFA_ADDRESS = "0x6EeE6060f715257b970700bc2656De21dEdF074C";
+        const IDA_ADDRESS = "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1";
+        const RIC_CONTRACT_ADDRESS = "0x263026e7e53dbfdce5ae55ade22493f828922965";
+
+        const streamExchangeHelper = await deploy("StreamExchangeHelper", {
+            from: deployer.address,
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        const streamExchange = await deploy("StreamExchange", {
+            from: deployer.address,
+            args: [
+                HOST_ADDRESS,
+                CFA_ADDRESS,
+                IDA_ADDRESS,
+                taskArgs.input,
+                taskArgs.output,
+                RIC_CONTRACT_ADDRESS,
+                taskArgs.router,
+                taskArgs.oracle,
+                taskArgs.requestid,
+                taskArgs.key
+            ],
+            libraries: {
+                StreamExchangeHelper: streamExchangeHelper.address
+            },
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        console.log("Deployed StreamExchangeHelper at: ", streamExchangeHelper.address);
+        console.log("Deployed StreamExchange at: ", streamExchange.address);
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchangeHelper.address
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchangeHelper at address ${streamExchangeHelper.address}`);
+        }
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchange.address,
+                constructorArguments: [
+                    HOST_ADDRESS,
+                    CFA_ADDRESS,
+                    IDA_ADDRESS,
+                    taskArgs.input,
+                    taskArgs.output,
+                    RIC_CONTRACT_ADDRESS,
+                    taskArgs.router,
+                    taskArgs.oracle,
+                    taskArgs.requestid,
+                    taskArgs.key
+                ]
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchange at address ${streamExchange.address}`);
+        }
+    });

--- a/01-Contracts/tasks/DeployPolygon.js
+++ b/01-Contracts/tasks/DeployPolygon.js
@@ -1,4 +1,4 @@
-task("DeployPolygon", "Deploys stream exchange contracts on Rinkeby testnet")
+task("DeployPolygon", "Deploys stream exchange contracts on Polygon mainnet")
     .addParam("input", "Input token address")
     .addParam("output", "Output token address")
     .addParam("router", "Router address (UniswapV2 type router) for swapping")

--- a/01-Contracts/tasks/DeployPolygon.js
+++ b/01-Contracts/tasks/DeployPolygon.js
@@ -1,10 +1,11 @@
-task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
+task("DeployPolygon", "Deploys stream exchange contracts on Rinkeby testnet")
     .addParam("input", "Input token address")
     .addParam("output", "Output token address")
     .addParam("router", "Router address (UniswapV2 type router) for swapping")
     .addParam("oracle", "Oracle address for the tokens")
     .addParam("requestid", "Request ID for Tellor oracle")
     .addParam("key", "Superfluid registeration key")
+    .addOptionalParam("check", "Checks and skips if the StreamExchange contract has already been deployed", true, types.boolean)
     .setAction(async (taskArgs, hre) => {
         const { deploy } = deployments;
         const [deployer] = await ethers.getSigners();
@@ -15,6 +16,9 @@ task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
         const IDA_ADDRESS = "0xB0aABBA4B2783A72C52956CDEF62d438ecA2d7a1";
         const RIC_CONTRACT_ADDRESS = "0x263026e7e53dbfdce5ae55ade22493f828922965";
 
+
+        // The following library doesn't use 'check' value as it will most likely remain unchanged
+        // hence no need for re-deployment.
         const streamExchangeHelper = await deploy("StreamExchangeHelper", {
             from: deployer.address,
             skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
@@ -37,7 +41,7 @@ task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
             libraries: {
                 StreamExchangeHelper: streamExchangeHelper.address
             },
-            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+            skipIfAlreadyDeployed: taskArgs.check // Make this false in case you are sure that the contract doesn't exist
         });
 
         console.log("Deployed StreamExchangeHelper at: ", streamExchangeHelper.address);

--- a/01-Contracts/tasks/DeployRinkeby.js
+++ b/01-Contracts/tasks/DeployRinkeby.js
@@ -1,0 +1,73 @@
+task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
+    .addParam("input", "Input token address")
+    .addParam("output", "Output token address")
+    .addParam("router", "Router address (UniswapV2 type router) for swapping")
+    .addParam("oracle", "Oracle address for the tokens")
+    .addParam("requestid", "Request ID for Tellor oracle")
+    .setAction(async (taskArgs, hre) => {
+        const { deploy } = deployments;
+        const [deployer] = await ethers.getSigners();
+
+        // Rinkeby testnet addresses
+        const HOST_ADDRESS = "0xeD5B5b32110c3Ded02a07c8b8e97513FAfb883B6";
+        const CFA_ADDRESS = "0xF4C5310E51F6079F601a5fb7120bC72a70b96e2A";
+        const IDA_ADDRESS = "0x32E0ecb72C1dDD92B007405F8102c1556624264D";
+        const RIC_CONTRACT_ADDRESS = "0x369A77c1A8A38488cc28C2FaF81D2378B9321D8B";
+
+
+        const streamExchangeHelper = await deploy("StreamExchangeHelper", {
+            from: deployer.address,
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        const streamExchange = await deploy("StreamExchange", {
+            from: deployer.address,
+            args: [
+                HOST_ADDRESS,
+                CFA_ADDRESS,
+                IDA_ADDRESS,
+                taskArgs.input,
+                taskArgs.output,
+                RIC_CONTRACT_ADDRESS,
+                taskArgs.router,
+                taskArgs.oracle,
+                taskArgs.requestid,
+                ""
+            ],
+            libraries: {
+                StreamExchangeHelper: streamExchangeHelper.address
+            },
+            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+        });
+
+        console.log("Deployed StreamExchangeHelper at: ", streamExchangeHelper.address);
+        console.log("Deployed StreamExchange at: ", streamExchange.address);
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchangeHelper.address
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchangeHelper at address ${streamExchangeHelper.address}`);
+        }
+
+        try {
+            await hre.run("verify:verify", {
+                address: streamExchange.address,
+                constructorArguments: [
+                    HOST_ADDRESS,
+                    CFA_ADDRESS,
+                    IDA_ADDRESS,
+                    taskArgs.input,
+                    taskArgs.output,
+                    RIC_CONTRACT_ADDRESS,
+                    taskArgs.router,
+                    taskArgs.oracle,
+                    taskArgs.requestid,
+                    ""
+                ]
+            });
+        } catch (error) {
+            console.log(`${error.message} for StreamExchange at address ${streamExchange.address}`);
+        }
+    });

--- a/01-Contracts/tasks/DeployRinkeby.js
+++ b/01-Contracts/tasks/DeployRinkeby.js
@@ -4,9 +4,11 @@ task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
     .addParam("router", "Router address (UniswapV2 type router) for swapping")
     .addParam("oracle", "Oracle address for the tokens")
     .addParam("requestid", "Request ID for Tellor oracle")
+    .addOptionalParam("check", "Checks and skips if the StreamExchange contract has already been deployed", true, types.boolean)
     .setAction(async (taskArgs, hre) => {
         const { deploy } = deployments;
         const [deployer] = await ethers.getSigners();
+
 
         // Rinkeby testnet addresses
         const HOST_ADDRESS = "0xeD5B5b32110c3Ded02a07c8b8e97513FAfb883B6";
@@ -14,7 +16,8 @@ task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
         const IDA_ADDRESS = "0x32E0ecb72C1dDD92B007405F8102c1556624264D";
         const RIC_CONTRACT_ADDRESS = "0x369A77c1A8A38488cc28C2FaF81D2378B9321D8B";
 
-
+        // The following library doesn't use 'check' value as it will most likely remain unchanged
+        // and hence no need for re-deployment.
         const streamExchangeHelper = await deploy("StreamExchangeHelper", {
             from: deployer.address,
             skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
@@ -37,7 +40,7 @@ task("DeployRinkeby", "Deploys stream exchange contracts on Rinkeby testnet")
             libraries: {
                 StreamExchangeHelper: streamExchangeHelper.address
             },
-            skipIfAlreadyDeployed: true // Make this false in case you are sure that the contract doesn't exist
+            skipIfAlreadyDeployed: taskArgs.check // Make this false in case you are sure that the contract doesn't exist
         });
 
         console.log("Deployed StreamExchangeHelper at: ", streamExchangeHelper.address);

--- a/01-Contracts/tasks/Distribute.js
+++ b/01-Contracts/tasks/Distribute.js
@@ -1,0 +1,14 @@
+task("Distribute", "Executes distribute function in a particular StreamExchange contract")
+    .addParam("address", "StreamExchange contract address")
+    .setAction(async (taskArgs) => {
+        const [owner] = await ethers.getSigners();
+        const StreamExchange = await ethers.getContractAt("StreamExchange", taskArgs.address, owner);
+        
+        try {
+            console.log(`Executing distribute function for StreamExchange contract at ${StreamExchange.address}...`);
+            await StreamExchange.distribute();
+            console.log(`Distribute function executed for StreamExchange contract at ${StreamExchange.address}`);
+        } catch (error) {
+            console.error(`Error for StreamExchange contract at ${StreamExchange.address}: ${error.message}`);
+        }
+    });

--- a/01-Contracts/tasks/SetOracle.js
+++ b/01-Contracts/tasks/SetOracle.js
@@ -1,0 +1,18 @@
+task("SetOracle", "Sets Tellor oracle address")
+    .addParam("address", "Address of the StreamExchange contract")
+    .addParam("oracle", "Address of the Tellor oracle")
+    .setAction(async (taskArgs) => {
+        const [owner] = await ethers.getSigners();
+        const StreamExchange = await ethers.getContractAt("StreamExchange", taskArgs.address, owner);
+        
+        try {
+            console.log(`Current Tellor oracle address: ${await StreamExchange.getTellorOracle()}`);
+            console.log(`Setting Tellor oracle address for StreamExchange at ${StreamExchange.address}...`);
+
+            await StreamExchange.setOracle(taskArgs.oracle);
+
+            console.log(`New Tellor oracle address for StreamExchange at ${StreamExchange.address} set to ${await StreamExchange.getTellorOracle()}`);
+        } catch (error) {
+            console.error(`Error for StreamExchange contract at ${StreamExchange.address}: ${error.message}`);
+        }
+    });

--- a/01-Contracts/tasks/SetRateTolerance.js
+++ b/01-Contracts/tasks/SetRateTolerance.js
@@ -1,0 +1,18 @@
+task("SetRateTolerance", "Sets rate tolerance in a StreamExchange contract")
+    .addParam("address", "Address of the StreamExchange contract")
+    .addParam("rate", "Rate to set in the StreamExchange contract")
+    .setAction(async (taskArgs) => {
+        const [owner] = await ethers.getSigners();
+        const StreamExchange = await ethers.getContractAt("StreamExchange", taskArgs.address, owner);
+
+        try {
+            console.log(`Current rate tolerance: ${await StreamExchange.getRateTolerance()}`);
+            console.log(`Setting rate tolerance to: ${taskArgs.rate}...`);
+
+            await StreamExchange.setRateTolerance(taskArgs.rate);
+
+            console.log(`Rate tolerance set to ${await StreamExchange.getRateTolerance()}`);
+        } catch (error) {
+            console.error(`Error for StreamExchange contract at ${StreamExchange.address}: ${error.message}`);
+        }
+    });

--- a/01-Contracts/tasks/SetSubsidyRate.js
+++ b/01-Contracts/tasks/SetSubsidyRate.js
@@ -1,0 +1,18 @@
+task("SetSubsidyRate", "Sets subsidy rate in a StreamExchange contract")
+    .addParam("address", "Address of the StreamExchange contract")
+    .addParam("rate", "Rate to set in the StreamExchange contract")
+    .setAction(async (taskArgs) => {
+        const [owner] = await ethers.getSigners();
+        const StreamExchange = await ethers.getContractAt("StreamExchange", taskArgs.address, owner);
+
+        try {
+            console.log(`Current subsidy rate: ${await StreamExchange.getSubsidyRate()}`);
+            console.log(`Setting subsidy rate to: ${taskArgs.rate}...`);
+
+            await StreamExchange.setSubsidyRate(taskArgs.rate);
+
+            console.log(`Subsidy rate set to ${await StreamExchange.getSubsidyRate()}`);
+        } catch (error) {
+            console.error(`Error for StreamExchange contract at ${StreamExchange.address}: ${error.message}`);
+        }
+    });

--- a/01-Contracts/tasks/TransferOwnership.js
+++ b/01-Contracts/tasks/TransferOwnership.js
@@ -1,0 +1,15 @@
+task("TransferOwnership", "Transfers ownership of StreamExchange type contracts")
+    .addParam("address", "StreamExchange contract address")
+    .addParam("owner", "Address of the new owner")
+    .setAction(async (taskArgs) => {
+        const [owner] = await ethers.getSigners();
+        const StreamExchange = await ethers.getContractAt("StreamExchange", taskArgs.address, owner);
+
+        try {
+            console.log(`Current owner: ${await StreamExchange.owner()}`);
+            await StreamExchange.transferOwnership(taskArgs.owner);
+            console.log(`New owner: ${await StreamExchange.owner()}`);
+        } catch (error) {
+            console.error(`Error for StreamExchange contract at ${StreamExchange.address}: ${error.message}`);
+        }
+    });


### PR DESCRIPTION
This PR is for issue #14  and issue #15 . For issue #15 , I corrected typos and added an optional param which allows for checking if a stream exchange market was already deployed. This can prevent accidental re-deployment of contracts. Instructions to execute are similar to that detailed in issue #15 PR comment. Also add the following lines of code in the `hardhat.config.js` file (assuming the task files are in the tasks folder):

```
require('./tasks/Distribute');
require('./tasks/SetRateTolerance');
require('./tasks/TransferOwnership');
require('./tasks/SetSubsidyRate');
require('./tasks/SetOracle');
```

I believe @mikeghen this should be enough for the tasks to work. Ping me if any other errors pop up.